### PR TITLE
fix: add contents:write permission for GitHub release step

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The \softprops/action-gh-release\ step failed with **403 'Resource not accessible by integration'** because the default GITHUB_TOKEN lacked write access to create releases.

This adds \permissions: contents: write\ at the workflow level.

Fixes https://github.com/yehiyam/redAutoAlert/actions/runs/23210075200