### PR TITLE
feat: show area names first in early-warning alerts for Android Auto

### DIFF
--- a/app/src/main/java/com/redautoalert/processor/AlertForwarder.kt
+++ b/app/src/main/java/com/redautoalert/processor/AlertForwarder.kt
@@ -144,7 +144,36 @@ class AlertForwarder(private val context: Context) : AlertProcessor {
             .build()
     }
 
-    private fun formatAlertText(event: AlertEvent): String = event.text
+    private fun formatAlertText(event: AlertEvent): String {
+        return extractAreas(event.text) ?: event.text
+    }
+
+    /**
+     * Early-warning alerts ("התרעה מקדימה") follow this pattern:
+     *   "בעקבות זיהוי שיגורים, בדקות הקרובות צפויות להתקבל התרעות באזורים X, Y, Z. לרשימת הישובים המלאה"
+     *
+     * Android Auto's notification preview only shows the first ~60 characters,
+     * so the actual area names are truncated. This method extracts the area list
+     * and places it at the start so drivers see the relevant info immediately.
+     */
+    internal fun extractAreas(text: String): String? {
+        val marker = "באזורים"
+        val markerIdx = text.indexOf(marker)
+        if (markerIdx < 0) return null
+
+        val afterMarker = text.substring(markerIdx + marker.length).trimStart()
+
+        // Strip the trailing "לרשימת הישובים המלאה" suffix if present
+        val suffix = "לרשימת הישובים המלאה"
+        val suffixIdx = afterMarker.indexOf(suffix)
+        val areas = if (suffixIdx >= 0) {
+            afterMarker.substring(0, suffixIdx).trimEnd('.', ' ', ',')
+        } else {
+            afterMarker.trimEnd('.', ' ', ',')
+        }
+
+        return areas.ifBlank { null }
+    }
 
     private fun createNotificationChannel() {
         val channel = NotificationChannel(


### PR DESCRIPTION
## Problem

Early-warning alerts from Tzofar have a long Hebrew preamble before the area names. Android Auto's notification preview truncates to ~60 characters, so the driver only sees the preamble and the actual area names are cut off.

## Solution

Modified `AlertForwarder.formatAlertText()` to detect the `באזורים` marker, extract the area names, and display them as the notification body. Regular alerts are passed through unchanged.